### PR TITLE
Fix the function name of `delete_queries`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1721,7 +1721,7 @@ pub mod gl {
             }
         }
 
-        pub fn delete_query(&self, ids: &[GLuint]) {
+        pub fn delete_queries(&self, ids: &[GLuint]) {
             match self {
                 Gl::Gl(gl) => unsafe { gl.DeleteQueries(ids.len() as GLsizei, ids.as_ptr()) },
                 Gl::Gles(gles) => {


### PR DESCRIPTION
Sorry, I mistyped the name of the Query deletion function, it should be `delete_queries`.