### PR TITLE
Fix build error on targets with c_char types != i8.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2004,7 +2004,7 @@ pub mod gl {
                     std::ffi::CString::new("_u".to_owned() + varying.as_str()).unwrap()
                 })
                 .collect::<Vec<_>>();
-            let pointers: Vec<*const i8> =
+            let pointers: Vec<*const c_char> =
                 c_varyings.iter().map(|p| p.as_ptr()).collect();
             match self {
                 Gl::Gl(gl) => unsafe { gl.TransformFeedbackVaryings(program, varyings.len() as _, pointers.as_ptr() as _, buffer_mode) },


### PR DESCRIPTION
Hi, since the recent update to 0.1.9, I'm seeing on macOS targeting aarch64-linux-android:

```bash
error[E0277]: a collection of type `std::vec::Vec<*const i8>` cannot be built from an iterator over elements of type `*const u8`
    --> /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/sparkle-0.1.9/src/lib.rs:2008:55
     |
2008 |                 c_varyings.iter().map(|p| p.as_ptr()).collect();
     |                                                       ^^^^^^^ a collection of type `std::vec::Vec<*const i8>` cannot be built from `std::iter::Iterator<Item=*const u8>`
     |
     = help: the trait `std::iter::FromIterator<*const u8>` is not implemented for `std::vec::Vec<*const i8>`
```

This PR uses `c_char` instead of `i8` for the definition of `pointers` to fix the compilation error on platforms where `c_char` is defined as `u8`.
