### PR TITLE
Add support fo calling read pixels with pixel pack buffer as target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1437,6 +1437,42 @@ pub mod gl {
             }
         }
 
+        pub fn read_pixels_into_pixel_pack_buffer(
+            &self,
+            x: GLint,
+            y: GLint,
+            width: GLsizei,
+            height: GLsizei,
+            format: GLenum,
+            pixel_type: GLenum,
+            buffer_byte_offset: usize,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.ReadPixels(
+                        x,
+                        y,
+                        width,
+                        height,
+                        format,
+                        pixel_type,
+                        buffer_byte_offset as *mut _,
+                    )
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.ReadPixels(
+                        x,
+                        y,
+                        width,
+                        height,
+                        format,
+                        pixel_type,
+                        buffer_byte_offset as *mut _,
+                    )
+                },
+            }
+        }
+
         pub fn read_pixels(
             &self,
             x: GLint,


### PR DESCRIPTION
This adds support for calling ReadPixels with a raw byte offset with the intention of reading into a bound pixel buffer object.