### PR TITLE
Add support for uniform buffer related functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"


### PR DESCRIPTION
This adds support for the following GL calls:

- GetUniformBlockIndex
- GetUniformIndices
- GetActiveUniformsiv
- GetActiveUniformBlockiv
- GetActiveUniformBlockName
- UniformBlockBinding
- BindBufferBase
- BindBufferRange

Related: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16