### PR TITLE
Add support for integer vertex attrib functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,6 +440,34 @@ pub mod gl {
             }
         }
 
+        pub fn vertex_attrib_4i(
+            &self,
+            index: GLuint,
+            x: GLint,
+            y: GLint,
+            z: GLint,
+            w: GLint,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe { gl.VertexAttribI4i(index, x, y, z, w) },
+                Gl::Gles(gles) => unsafe { gles.VertexAttribI4i(index, x, y, z, w) },
+            }
+        }
+
+        pub fn vertex_attrib_4ui(
+            &self,
+            index: GLuint,
+            x: GLuint,
+            y: GLuint,
+            z: GLuint,
+            w: GLuint,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe { gl.VertexAttribI4ui(index, x, y, z, w) },
+                Gl::Gles(gles) => unsafe { gles.VertexAttribI4ui(index, x, y, z, w) },
+            }
+        }
+
         pub fn vertex_attrib_pointer_f32(
             &self,
             index: GLuint,


### PR DESCRIPTION
Adds support for the `VertexAttribI4[u]i` GL calls.

Related: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8