### PR TITLE
Add support for some more renderbuffer operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         "GL_ARB_texture_rectangle",
         "GL_EXT_texture_filter_anisotropic",
         "GL_ARB_transform_feedback2",
+        "GL_ARB_internalformat_query",
     ];
     let gl_reg = Registry::new(
         Api::Gl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,6 +907,23 @@ pub mod gl {
             result
         }
 
+        pub fn get_internal_format_iv(
+            &self,
+            target: GLenum,
+            internalformat: GLenum,
+            pname: GLenum,
+            result: &mut [GLint],
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.GetInternalformativ(target, internalformat, pname, result.len() as _, result.as_mut_ptr())
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.GetInternalformativ(target, internalformat, pname, result.len() as _, result.as_mut_ptr())
+                },
+            }
+        }
+
         pub fn get_renderbuffer_parameter_iv(&self, target: GLenum, pname: GLenum) -> GLint {
             let mut result = 0;
             match self {
@@ -1156,6 +1173,24 @@ pub mod gl {
                 },
                 Gl::Gles(gles) => unsafe {
                     gles.RenderbufferStorage(target, internalformat, width, height)
+                },
+            }
+        }
+
+        pub fn renderbuffer_storage_multisample(
+            &self,
+            target: GLenum,
+            samples: GLsizei,
+            internalformat: GLenum,
+            width: GLsizei,
+            height: GLsizei,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.RenderbufferStorageMultisample(target, samples, internalformat, width, height)
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.RenderbufferStorageMultisample(target, samples, internalformat, width, height)
                 },
             }
         }


### PR DESCRIPTION
Adds support for the `GetInternalformativ` and `RenderbufferStorageMultisample` GL calls.

See https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5