### PR TITLE
Add support for framebuffer invalidation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
         "GL_EXT_texture_filter_anisotropic",
         "GL_ARB_transform_feedback2",
         "GL_ARB_internalformat_query",
+        "GL_ARB_invalidate_subdata",
     ];
     let gl_reg = Registry::new(
         Api::Gl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1160,6 +1160,60 @@ pub mod gl {
             }
         }
 
+        pub fn invalidate_framebuffer(&self, target: GLenum, attachments: &[GLenum]) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.InvalidateFramebuffer(
+                        target,
+                        attachments.len() as GLsizei,
+                        attachments.as_ptr(),
+                    )
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.InvalidateFramebuffer(
+                        target,
+                        attachments.len() as GLsizei,
+                        attachments.as_ptr(),
+                    )
+                },
+            }
+        }
+
+        pub fn invalidate_sub_framebuffer(
+            &self,
+            target: GLenum,
+            attachments: &[GLenum],
+            x: i32,
+            y: i32,
+            width: GLsizei,
+            height: GLsizei,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.InvalidateSubFramebuffer(
+                        target,
+                        attachments.len() as GLsizei,
+                        attachments.as_ptr(),
+                        x,
+                        y,
+                        width,
+                        height,
+                    )
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.InvalidateSubFramebuffer(
+                        target,
+                        attachments.len() as GLsizei,
+                        attachments.as_ptr(),
+                        x,
+                        y,
+                        width,
+                        height,
+                    )
+                },
+            }
+        }
+
         pub fn renderbuffer_storage(
             &self,
             target: GLenum,


### PR DESCRIPTION
Adds support for the `invalidateFramebuffer` and `invalidateSubFramebuffer` calls.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4