### PR TITLE
Add support for framebuffer texture layer operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1160,6 +1160,36 @@ pub mod gl {
             }
         }
 
+        pub fn framebuffer_texture_layer(
+            &self,
+            target: GLenum,
+            attachment: GLenum,
+            texture: GLuint,
+            level: GLint,
+            layer: GLint,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.FramebufferTextureLayer(
+                        target,
+                        attachment,
+                        texture,
+                        level,
+                        layer,
+                    )
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.FramebufferTextureLayer(
+                        target,
+                        attachment,
+                        texture,
+                        level,
+                        layer,
+                    )
+                },
+            }
+        }
+
         pub fn invalidate_framebuffer(&self, target: GLenum, attachments: &[GLenum]) {
             match self {
                 Gl::Gl(gl) => unsafe {


### PR DESCRIPTION
Adds support for `FramebufferTextureLayer` GL call.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4