### PR TITLE
Add support for the `ReadBuffer` GL call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1043,6 +1043,13 @@ pub mod gl {
             }
         }
 
+        pub fn read_buffer(&self, buffer: GLenum) {
+            match self {
+                Gl::Gl(gl) => unsafe { gl.ReadBuffer(buffer) },
+                Gl::Gles(gles) => unsafe { gles.ReadBuffer(buffer) },
+            }
+        }
+
         pub fn draw_buffers(&self, bufs: &[GLenum]) {
             let len = bufs.len() as GLsizei;
             match self {


### PR DESCRIPTION
See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4