### PR TITLE
Add support for texture storage calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.22"
+version = "0.1.23"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
         "GL_APPLE_vertex_array_object",
         "GL_ARB_texture_rectangle",
         "GL_EXT_texture_filter_anisotropic",
+        "GL_ARB_texture_storage",
         "GL_ARB_transform_feedback2",
         "GL_ARB_internalformat_query",
         "GL_ARB_invalidate_subdata",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,43 @@ pub mod gl {
             }
         }
 
+        pub fn tex_storage_2d(
+            &self,
+            target: GLenum,
+            levels: GLsizei,
+            internal_format: GLenum,
+            width: GLsizei,
+            height: GLsizei,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.TexStorage2D(target, levels, internal_format, width, height)
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.TexStorage2D(target, levels, internal_format, width, height)
+                },
+            }
+        }
+
+        pub fn tex_storage_3d(
+            &self,
+            target: GLenum,
+            levels: GLsizei,
+            internal_format: GLenum,
+            width: GLsizei,
+            height: GLsizei,
+            depth: GLsizei,
+        ) {
+            match self {
+                Gl::Gl(gl) => unsafe {
+                    gl.TexStorage3D(target, levels, internal_format, width, height, depth)
+                },
+                Gl::Gles(gles) => unsafe {
+                    gles.TexStorage3D(target, levels, internal_format, width, height, depth)
+                },
+            }
+        }
+
         pub fn generate_mipmap(&self, target: GLenum) {
             match self {
                 Gl::Gl(gl) => unsafe { gl.GenerateMipmap(target) },


### PR DESCRIPTION
Adds support for `TexStorage2D` and `TexStorage3D`.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6