### PR TITLE
Add support for the pbo offset variant of TexImage2D

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkle"
 license = "MIT / Apache-2.0"
-version = "0.1.24"
+version = "0.1.25"
 authors = ["Josh Matthews <josh@joshmatthews.net>"]
 description = "GL bindings for Servo's WebGL implementation."
 repository = "https://github.com/servo/sparkle"


### PR DESCRIPTION
See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6

I've also increased the version number for the crate.